### PR TITLE
Support all node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 language: node_js
 
 node_js:
+  - "node"
+  - "lts/*"
   - "8"
+  - "7"
+  - "6"
+  - "5"
+  - "4"
 
 sudo: false
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,9 @@
     "testPathIgnorePatterns": [
       "node_modules",
       "dist"
+    ],
+    "setupFiles": [
+      "<rootDir>/node_modules/babel-polyfill/lib/index.js"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
Node versions supported:

- latest stable
- latest LTS
- v8
- v7
- v6
- v5
- v4

Travis runs the tests against each version.

Jest v20+ does not pull in `babel-polyfill` by default so that had to be done via the `setupFiles` option in the Jest config to support running the tests under older versions of Node requiring some polyfills used in `eslint-summary-formatter` codebase e.g. `String.padStart()`