### PR TITLE
Default sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ In the above example we can notice that the `comma-dangle` rule is responsible f
 
 ## Sorting output
 
+> Default sorting is by `rule` in an `ascending` order
+
 Configuration options can be passed to the formatter to alter the output.
 
 Using the`SORT_BY` env var the aggregated results can be sorted by either `rule`, `errors` or `warnings` e.g.

--- a/lib/__tests__/__snapshots__/format-results.spec.js.snap
+++ b/lib/__tests__/__snapshots__/format-results.spec.js.snap
@@ -48,6 +48,14 @@ errors 0 warnings 1 rule: rule1
 🔥  4 problems in total (1 errors, 3 warnings)"
 `;
 
+exports[`defaults to sorting summary by rule id / ascending 1`] = `
+" ✨  Summary of failing ESLint rules 
+errors 1 warnings 1 rule: A
+errors 0 warnings 1 rule: B
+errors 1 warnings 1 rule: C
+🔥  5 problems in total (2 errors, 3 warnings)"
+`;
+
 exports[`omits result for ignored files 1`] = `
 " ✨  Summary of failing ESLint rules 
 errors 0 warnings 1 rule: rule1

--- a/lib/__tests__/format-results.spec.js
+++ b/lib/__tests__/format-results.spec.js
@@ -21,6 +21,21 @@ test('provides header, summary of rules and total', () => {
   expect(stripAnsi(format(results, {}))).toMatchSnapshot();
 });
 
+test('defaults to sorting summary by rule id / ascending', () => {
+  const results = [
+    mockResult([
+      ['B', 1],
+      ['C', 2],
+      ['A', 2],
+    ]),
+    mockResult([
+      ['A', 1],
+      ['C', 1],
+    ]),
+  ];
+  expect(stripAnsi(format(results, {}))).toMatchSnapshot();
+});
+
 test('can sort summary by rule id', () => {
   const results = [
     mockResult([

--- a/lib/format-results.js
+++ b/lib/format-results.js
@@ -62,6 +62,9 @@ export default function format(results, { SORT_BY, DESC }) {
     const prop = SORT_BY === 'rule' ? 'ruleId' : SORT_BY;
     const direction = DESC === 'true' ? 'desc' : 'asc';
     sortBy(prop, rules, direction);
+  } else {
+    // default sorting is by rule / ascending
+    sortBy('ruleId', rules, 'asc');
   }
 
   const header = constructHeader(rules);


### PR DESCRIPTION
Formatter now defaults to sorting by rule / ascending to help overseeing the results.