### PR TITLE
Move `np` to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,10 +93,8 @@
     "husky": "^4.3.0",
     "jest": "^26.6.3",
     "lint-staged": "^10.5.4",
+    "np": "^7.4.0",
     "prettier": "^2.2.1",
     "strip-ansi": "^6.0.0"
-  },
-  "optionalDependencies": {
-    "np": "^7.4.0"
   }
 }


### PR DESCRIPTION
The np dependency is only used in the release scripts and should not be
marked as an optional runtime dependency.

Having np be installed as an optional runtime dependency is causing
warnings on npm and yarn installation of the eslint-formatter-summary
package due to issues in the dependencies of np such as security
vulnerabilities and warnings about the `engines` block defined by np.

This resolves #36 