### PR TITLE
Bump strip-ansi from 6.0.0 to 6.0.1 to resolve SNYK-JS-ANSIREGEX-1583908

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "jest": "^26.6.3",
     "lint-staged": "^10.5.4",
     "prettier": "^2.2.1",
-    "strip-ansi": "^6.0.0"
+    "strip-ansi": "^6.0.1"
   },
   "optionalDependencies": {
     "np": "^7.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1175,7 +1175,7 @@
     p-each-series "^2.1.0"
     rimraf "^3.0.0"
     slash "^3.0.0"
-    strip-ansi "^6.0.0"
+    strip-ansi "^6.0.1"
 
 "@jest/environment@^26.6.2":
   version "26.6.2"


### PR DESCRIPTION
This PR is in response to https://security.snyk.io/vuln/SNYK-JS-ANSIREGEX-1583908 strip-ansi 6.0.0 is vulnerable, but 6.0.1 has been updated. This PR updates package.json and yarn.lock to update strip-ansi to 6.0.1

I did test locally with `npm run test`. If you're interested in having a workflow added to validate that test passes before allowing PR, say the word and I'll setup another PR to do that. I manage our companies pr-merge-checks and eslint checks on top of helping with security updates like the one that led to this PR.