### PR TITLE
Add JSON output support

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ See https://github.com/sindresorhus/np for more options.
 ## Possible improvements / planned features
 
 - allow different output showing files with aggregated number of errors / warnings
-- export results as JSON
 - export each rule turned off and ready to be added to `.eslintrc`
 - show fixable summart #20
 - export output as markdown #33

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -8,4 +8,5 @@ await esbuild.build({
   target: 'node20',
   outdir: 'dist',
   sourcemap: 'linked',
+  format: 'esm',
 });

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-const format = require('./dist/index.js');
+import format from './dist/format-results.js';
 
-module.exports = function formatter(results) {
-  console.log(format(results, process.env));
-};
+export default function formatter(results) {
+  return format(results, process.env);
+}

--- a/lib/format-results.spec.ts
+++ b/lib/format-results.spec.ts
@@ -92,6 +92,36 @@ describe('formatResults', () => {
     ).toMatchSnapshot();
   });
 
+  test('can output summary in json format', () => {
+    const results = [
+      mockLintResult([
+        ['rule1', 1],
+        ['rule2', 2],
+      ]),
+    ];
+    const output = JSON.parse(format(results, { FORMAT: 'json' }));
+
+    expect(output).toEqual({
+      summary: {
+        rule1: {
+          errors: 0,
+          warnings: 1,
+        },
+        rule2: {
+          errors: 1,
+          warnings: 0,
+        },
+      },
+      total: {
+        total: {
+          errors: 1,
+          warnings: 1,
+          problems: 2,
+        },
+      },
+    });
+  });
+
   // test('omits result for ignored files', () => {
   //   const ignoredFileResults: ESLint.LintResult = {
   //     filePath: 'test.js',


### PR DESCRIPTION
This pull requests adds support for JSON output as mentioned as a possible improvement in the `README.md`.
JSON output is great for machine-readability and for using the output as part of a CI/CD pipeline.

The default formatter behavior remains unchanged. It is still text output, but when the `FORMAT=json` environment variable is set, the output switches to JSON.

Since the project is currently in the process of being rewritten, I decided to target the `v2-rewrite` branch already in order to avoid a future rebase. I think the change can either be merged into the `v2-rewrite` branch already or alternatively become a follow-up pull request once the rewrite gets merged into `main`.

Note that I added `format: 'esm'` to `esbuild.config.mjs` and changed the `index.js` file because it was necessary to get the project to build on my end. I followed the instructions in the documentation, but I'm not a TypeScript expert, so there is a chance I've overlooked something. I double-checked and my Node version is the latest LTS (v22.14.0).

I'd be thankful for a code review.