### PR TITLE
Feature: Add JSON output support

### DIFF
--- a/lib/format-results.spec.ts
+++ b/lib/format-results.spec.ts
@@ -92,6 +92,34 @@ describe('formatResults', () => {
     ).toMatchSnapshot();
   });
 
+  test('can output summary in json format', () => {
+    const results = [
+      mockLintResult([
+        ['rule1', 1],
+        ['rule2', 2],
+      ]),
+    ];
+    const output = JSON.parse(format(results, { FORMAT: 'json' }));
+
+    expect(output).toEqual({
+      summary: {
+        rule1: {
+          errors: 0,
+          warnings: 1,
+        },
+        rule2: {
+          errors: 1,
+          warnings: 0,
+        },
+      },
+      total: {
+        errors: 1,
+        warnings: 1,
+        problems: 2,
+      },
+    });
+  });
+
   // test('omits result for ignored files', () => {
   //   const ignoredFileResults: ESLint.LintResult = {
   //     filePath: 'test.js',

--- a/lib/format-results.ts
+++ b/lib/format-results.ts
@@ -37,6 +37,15 @@ const constructSummary = (rules: Rule[]) =>
     })
     .join('');
 
+const constructJsonSummary = (rules: Rule[]) =>
+  rules.reduce<Record<string, { errors: number; warnings: number }>>(
+    (acc, rule) => {
+      acc[rule.ruleId] = { errors: rule.errors, warnings: rule.warnings };
+      return acc;
+    },
+    {},
+  );
+
 const constructTotal = (rules: Rule[]) =>
   chalk`${flames}  {red ${totalProblems(
     rules,
@@ -47,6 +56,15 @@ const constructTotal = (rules: Rule[]) =>
 type EnvVars = {
   SORT_BY?: 'rule' | 'errors' | 'warnings';
   DESC?: 'true';
+  FORMAT?: 'json' | 'text';
+};
+
+const constructJsonTotal = (rules: Rule[]) => {
+  return {
+    errors: totalErrors(rules),
+    warnings: totalWarnings(rules),
+    problems: totalProblems(rules),
+  };
 };
 
 /**
@@ -62,7 +80,7 @@ type EnvVars = {
  */
 export const format = (
   results: ESLint.LintResult[],
-  { SORT_BY = 'rule', DESC }: EnvVars,
+  { SORT_BY = 'rule', DESC, FORMAT = 'text' }: EnvVars,
 ): string => {
   const rules = aggregate(results);
 
@@ -73,6 +91,12 @@ export const format = (
   } else {
     // default sorting is by rule / ascending
     sortBy('ruleId', rules, 'asc');
+  }
+
+  if (FORMAT === 'json') {
+    const summary = constructJsonSummary(rules);
+    const total = constructJsonTotal(rules);
+    return JSON.stringify({ summary, total }, null, 2);
   }
 
   const header = constructHeader(rules);


### PR DESCRIPTION
This PR is a re-implementation of #46 (with some minor alterations) made by @mre-trv on Feb. 12, 2025.  I am re-implementing their solution here, since there has not been activity on that PR for several months, and I'd like to utilize this feature.  

This PR does the following:
- Adds support for JSON output when generating a summary
- Adds a unit test

This PR does not include the build changes to the project that @mre-trv made in #46.

@mhipszki if there are any issues, please let me know. I am excited to see this feature merged.