### PR TITLE
Refactor constructTotal for positive output formatting

### DIFF
--- a/lib/format-results.ts
+++ b/lib/format-results.ts
@@ -39,7 +39,7 @@ const constructSummary = (rules: Rule[]) =>
 
 const constructTotal = (rules: Rule[]) => {
   const totalCount = totalProblems(rules);
-  const formattedTotal = totalCount === 0 ? `${sparkles}  {green ${totalCount} problems in total}` : `${flames}  {red ${totalCount)} problems in total}`;
+  const formattedTotal = totalCount === 0 ? `${sparkles}  {green ${totalCount} problems in total}` : `${flames}  {red ${totalCount} problems in total}`;
   return chalk`${formattedTotal} (${totalErrors(rules)} {red errors}, ${totalWarnings(rules)} {yellow warnings})`;
 }
 

--- a/lib/format-results.ts
+++ b/lib/format-results.ts
@@ -37,12 +37,11 @@ const constructSummary = (rules: Rule[]) =>
     })
     .join('');
 
-const constructTotal = (rules: Rule[]) =>
-  chalk`${flames}  {red ${totalProblems(
-    rules,
-  )} problems in total} (${totalErrors(rules)} {red errors}, ${totalWarnings(
-    rules,
-  )} {yellow warnings})`;
+const constructTotal = (rules: Rule[]) => {
+  const totalCount = totalProblems(rules);
+  const formattedTotal = totalCount === 0 ? `${sparkles}  {green ${totalCount} problems in total}` : `${flames}  {red ${totalCount)} problems in total}`;
+  return chalk`${formattedTotal} (${totalErrors(rules)} {red errors}, ${totalWarnings(rules)} {yellow warnings})`;
+}
 
 type EnvVars = {
   SORT_BY?: 'rule' | 'errors' | 'warnings';


### PR DESCRIPTION
This pull request updates the summary formatting logic in `lib/format-results.ts` to improve how the total number of problems is displayed. The main change is that when there are zero problems, the summary line now uses a green color and a sparkles icon, making it visually distinct from cases where there are problems.

Improvements to summary output:

* The `constructTotal` function now displays a green-colored message with a sparkles icon when there are zero problems, instead of always using a red flames icon.
* For cases with problems, the summary format remains mostly unchanged, but the string construction is now clearer and more readable.